### PR TITLE
Adjusting vh for .dapp-sidebar since the migrate button is whited out in dark mode

### DIFF
--- a/src/components/Sidebar/NavContent/index.tsx
+++ b/src/components/Sidebar/NavContent/index.tsx
@@ -51,7 +51,7 @@ function NavContent() {
 
   return (
     <Paper className="dapp-sidebar">
-      <Box className="dapp-sidebar" display="flex" justifyContent="flex-end" flexDirection="column">
+      <Box className="dapp-sidebar" display="flex" justifyContent="space-between" flexDirection="column">
         <div className="dapp-menu-top">
           <Link href="https://www.otterclam.finance" target="_blank">
             <Box display="flex" flexDirection="column" className="branding-header">

--- a/src/components/Sidebar/NavContent/index.tsx
+++ b/src/components/Sidebar/NavContent/index.tsx
@@ -51,7 +51,7 @@ function NavContent() {
 
   return (
     <Paper className="dapp-sidebar">
-      <Box className="dapp-sidebar" display="flex" justifyContent="space-between" flexDirection="column">
+      <Box className="dapp-sidebar" display="flex" justifyContent="flex-end" flexDirection="column">
         <div className="dapp-menu-top">
           <Link href="https://www.otterclam.finance" target="_blank">
             <Box display="flex" flexDirection="column" className="branding-header">

--- a/src/components/Sidebar/sidebar.scss
+++ b/src/components/Sidebar/sidebar.scss
@@ -11,7 +11,7 @@
 }
 
 .dapp-sidebar {
-  height: 100vh;
+  height: 115vh;
   border-radius: 0 !important;
 }
 


### PR DESCRIPTION
I saw in chat how other people said they were able to see the 'Migrate' tab but I was not able to because I'm in dark mode. I think a simple change in adjusting vh up from 100 to 115 should be minimal impact yet enable visibility.

Before: 
![image](https://user-images.githubusercontent.com/35601444/142717505-eb110582-7997-407a-ac61-9b0ad4329c55.png)

After:
![image](https://user-images.githubusercontent.com/35601444/142717549-ce0cbacc-db9e-4dea-a631-f351a777e700.png)
