### PR TITLE
Fix APY runway with Dark Theme

### DIFF
--- a/src/views/Dashboard/TreasuryDashboard.tsx
+++ b/src/views/Dashboard/TreasuryDashboard.tsx
@@ -324,7 +324,9 @@ function TreasuryDashboard() {
                     // @ts-ignore
                     headerSubText={`${data && trim(data[0].runwayCurrent, 1)} Days`}
                     dataFormat="days"
-                    bulletpointColors={bulletpoints.runway}
+                    bulletpointColors={
+                      theme.palette.text.primary == '#1D2654' ? bulletpoints.runway : bulletpoints.runway_darktheme
+                    }
                     itemNames={tooltipItems.runway}
                     itemType={''}
                     infoTooltipMessage={tooltipInfoMessages.runway}

--- a/src/views/Dashboard/treasuryData.js
+++ b/src/views/Dashboard/treasuryData.js
@@ -133,6 +133,28 @@ export const bulletpoints = {
       background: '#c9184a',
     },
   ],
+  runway_darktheme: [
+    {
+      right: 45,
+      top: -12,
+      background: '#FFFFFF',
+    },
+    {
+      right: 48,
+      top: -12,
+      background: '#2EC608',
+    },
+    {
+      right: 48,
+      top: -12,
+      background: '#49A1F2',
+    },
+    {
+      right: 48,
+      top: -12,
+      background: '#c9184a',
+    },
+  ],
   staked: [
     {
       right: 45,


### PR DESCRIPTION
Sorry, I forgot one! The APY Runway chart now changes the tooltip colour based on Dark Theme or Light Theme.