### PR TITLE
Fix Overflow on Bonds page

### DIFF
--- a/src/views/Bond/bond.scss
+++ b/src/views/Bond/bond.scss
@@ -1,5 +1,8 @@
 @import 'styles/_colors.scss';
-
+.MuiPaper-root.ohm-card {
+  width: unset !important;
+  max-width: none !important;
+}
 #bond-view {
   position: absolute !important;
   width: 100%;


### PR DESCRIPTION
A little hacky lol, but this fixes the Bonds page content overflowing and requiring a horizontal scroll bar. Also worked fine in Mobile Mode of my Chrome Dev Tools.